### PR TITLE
fix: ignore import inside strings better

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "webpack-chunkname-loader",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "loader-utils": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-chunkname-loader",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Add webpackChunkName magic comments to your dynamic imports",
   "main": "dist",
   "type": "module",

--- a/src/update.js
+++ b/src/update.js
@@ -1,5 +1,5 @@
 const dynamicImportsWithoutComments =
-  /(?<![\w.]|#!|\*[\s\w]*?|\/\/\s*|['"``]\s*)import\s*\((?!\s*\/\*)(?<path>\s*?['"`][^)]+['"`]\s*)\)(?!\s*?\*\/)/g
+  /(?<![\w.]|#!|\*[\s\w]*?|\/\/\s*|['"`][^)$]*)import\s*\((?!\s*\/\*)(?<path>\s*?['"`][^)]+['"`]\s*)\)(?!\s*?\*\/)/g
 const getReplacer =
   (filepath, options = {}) =>
   (match, capturedImportPath) => {


### PR DESCRIPTION
* Fixes a bug where imports inside strings were not ignored.
  ```js
  // This will be ignored
  const str = 'abc123 import("some/path")~xyz'
  
  // This will not be ignored (any string with a '$')
  const tmplStr = `abc123~${import('some/module')}~xyz`
  ```